### PR TITLE
テスト用関数の分離 / CORSテスト対応

### DIFF
--- a/svc/cmd/dev/main.go
+++ b/svc/cmd/dev/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	engine := gin.New()
 	apiV1 := engine.Group("/api/v1")
-	err := runner.Implement(apiV1)
+	err := runner.Implement(apiV1, true)
 	if err != nil {
 		log.Fatalf("Failed to start server... %v", err)
 		return

--- a/svc/pkg/domain/model/user/gender.go
+++ b/svc/pkg/domain/model/user/gender.go
@@ -11,7 +11,7 @@ const (
 )
 
 func NewGender(gender int) (Gender, error) {
-	switch gender {
+	switch Gender(gender) {
 	case GenderMan:
 		return GenderMan, nil
 	case GenderWoman:

--- a/svc/runner/server.go
+++ b/svc/runner/server.go
@@ -8,7 +8,7 @@ import (
 	"ynufes-mypage-backend/svc/pkg/registry"
 )
 
-func Implement(rg *gin.RouterGroup) error {
+func Implement(rg *gin.RouterGroup, devTool bool) error {
 	rgst, err := registry.New()
 	if err != nil {
 		return err
@@ -17,8 +17,17 @@ func Implement(rg *gin.RouterGroup) error {
 	rg.Handle("GET", "/auth/line/callback", lineAuth.VerificationHandler())
 	rg.Handle("GET", "/auth/line/state", lineAuth.StateIssuer())
 
-	//method for development purpose
-	rg.Handle("GET", "/auth/line/dev", lineAuth.DevAuth())
+	if devTool {
+		//method for development purpose
+		rg.Handle("GET", "/auth/line/dev", lineAuth.DevAuth())
+		rg.OPTIONS("/*any", func(c *gin.Context) {
+			c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+			c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+			c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
+			c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+			c.AbortWithStatus(200)
+		})
+	}
 
 	middlewareAuth := middleware.NewAuth(*rgst)
 

--- a/svc/runner/server_test.go
+++ b/svc/runner/server_test.go
@@ -13,7 +13,7 @@ func TestImplement(t *testing.T) {
 	r := gin.Default()
 	w := httptest.NewRecorder()
 	rg := r.Group("/api/v1")
-	err := Implement(rg)
+	err := Implement(rg, true)
 	assert.NoError(t, err)
 	req, _ := http.NewRequest("GET", "/api/v1/auth/line/state", nil)
 	r.ServeHTTP(w, req)


### PR DESCRIPTION
# 実装したこと
- #11 CORS対応
- テスト用API関数の分離