### PR TITLE
🛂 認証情報付与形式の変更

### DIFF
--- a/svc/pkg/handler/agent/org.go
+++ b/svc/pkg/handler/agent/org.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"github.com/gin-gonic/gin"
 	"log"
 	"time"
@@ -53,7 +54,8 @@ func (o Org) CreateHandler() gin.HandlerFunc {
 		opt, err := o.createOrgUC.Do(ipt)
 		if err != nil {
 			log.Printf("failed to create org in CreateOrgHandler: %v", err)
-			c.AbortWithStatusJSON(500, gin.H{"error": "failed to create org"})
+			c.AbortWithStatusJSON(500,
+				gin.H{"error": fmt.Sprintf("failed to create org: %v", err)})
 			return
 		}
 		resp := agent.CreateOrgResponse{


### PR DESCRIPTION
| Property            | Value |
|:--------------------|:------|
| Corresponding Issue | #59   |
| Assignee            | @Shion1305 |

# PRで実装される機能
- Tokenをクエリで付与することによる認証情報付与

認証の流れとしては以下。
1. LINEで認証を行う
2. LINEからcallbackエンドポイントが叩かれる
3. backend側で情報を受け取り認証Tokenを生成
4. Frontend `/token` にtokenクエリで認証Tokenをつけた状態でリダイレクトさせる
5. Frontend側で受け取り、sessionStorageにPiniaで保存したのち、Home画面にリダイレクトさせる

# レビューをお願いしたいポイント
フロントエンド側との連携を確認してほしい

対応するフロントエンドのPRは以下。
https://github.com/shion1305/ynufes-mypage-frontend/pull/40